### PR TITLE
Make Go serve the front end as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,15 @@ README.md
 
 ## Build and Run
 
+When running for the first time, do
+
+```
+cd web && yarn build
+```
+
+This generates the static site in `./web/build` which is then served by the Go server when you run `make build && make run`.
+
+
 ### Make commands
 
 - `make clean` - cleans the project
@@ -29,3 +38,11 @@ README.md
 - `make run` - runs the project
 
 Then navigate to localhost:8080
+
+### Front end development
+
+```
+yarn start
+```
+
+More information in [front end specific README(web/README.md)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -17,6 +17,7 @@ import (
 )
 
 func init() {
+	log.Print("Initialising")
 	if err := godotenv.Load(); err != nil {
 		log.Print("No .env file found")
 	}
@@ -49,6 +50,7 @@ func (h webHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func main() {
+	log.Print("Starting main")
 
 	router := mux.NewRouter().StrictSlash(true)
 

--- a/makefile
+++ b/makefile
@@ -13,6 +13,11 @@ build:
 	@echo "Building $(GOFILES) to ./bin"
 	@GOBIN=$(GOBIN) go build -mod=mod -o bin/$(GONAME) $(GOFILES) 
 
+buildaws:
+	@GOBIN=$(GOBIN) GOARCH=amd64 GOOS=linux go build -mod=mod -o bin/application $(GOFILES) 
+	-rm ebUpload.zip
+	zip -r bin/ebUpload.zip bin/application web/build
+
 # get:
 #   @GOPATH=$(GOPATH) GOBIN=$(GOBIN) go get .
 

--- a/makefile
+++ b/makefile
@@ -15,8 +15,9 @@ build:
 
 buildaws:
 	@GOBIN=$(GOBIN) GOARCH=amd64 GOOS=linux go build -mod=mod -o bin/application $(GOFILES) 
-	-rm ebUpload.zip
-	zip -r bin/ebUpload.zip bin/application web/build
+	@cd web && yarn build
+	@-rm bin/ebUpload.zip
+	@zip -r bin/ebUpload.zip bin/application web/build
 
 # get:
 #   @GOPATH=$(GOPATH) GOBIN=$(GOBIN) go get .

--- a/web/.env
+++ b/web/.env
@@ -1,1 +1,0 @@
-REACT_APP_API_URL=http://localhost:8080/api/

--- a/web/.env
+++ b/web/.env
@@ -1,1 +1,1 @@
-REACT_APP_API_URL=http://localhost:8080/
+REACT_APP_API_URL=http://localhost:8080/api/

--- a/web/package.json
+++ b/web/package.json
@@ -19,7 +19,7 @@
     "react-dom": "^16.13.1",
     "react-redux": "^7.2.0",
     "react-router-dom": "^5.2.0",
-    "react-scripts": "3.4.1",
+    "react-scripts": "^3.4.1",
     "redux-devtools-extension": "^2.13.8",
     "redux-saga": "^1.1.3",
     "typesafe-actions": "^5.1.0",
@@ -49,5 +49,6 @@
   },
   "devDependencies": {
     "tailwindcss": "^1.4.6"
-  }
+  },
+  "proxy": "http://localhost:8080/"
 }

--- a/web/src/store/crossword/crosswordSaga.ts
+++ b/web/src/store/crossword/crosswordSaga.ts
@@ -15,11 +15,11 @@ function* getCrossword(
   >
 ) {
   const url =
-    process.env.REACT_APP_API_URL +
-    "getcrossword/" +
+    "/api/getcrossword/" +
     action.payload.crosswordId;
 
   try {
+    console.log(url);
     const response = yield call(() => axios.get(url));
     console.log(response.data);
     yield put(getCrosswordSuccess(response.data));

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -9090,7 +9090,7 @@ react-router@5.2.0:
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
 
-react-scripts@3.4.1:
+react-scripts@^3.4.1:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/react-scripts/-/react-scripts-3.4.1.tgz#f551298b5c71985cc491b9acf3c8e8c0ae3ada0a"
   integrity sha512-JpTdi/0Sfd31mZA6Ukx+lq5j1JoKItX7qqEK4OiACjVQletM1P38g49d9/D0yTxp9FrSF+xpJFStkGgKEIRjlQ==


### PR DESCRIPTION
This is only really for production and not development. Keep doing `yarn start` when checking changes when writing code for the front end. 
Though about putting `cd web && yarn build` into `make build` but thought it would slow down build too much, and we only ever need to do it once anyway :)